### PR TITLE
Use 0b prefix for binary values, not 0x.

### DIFF
--- a/DS3231.cpp
+++ b/DS3231.cpp
@@ -334,9 +334,9 @@ void DS3231::setClockMode(bool h12) {
 
 	// Set the flag to the requested value:
 	if (h12) {
-		temp_buffer = temp_buffer | 0x01000000;
+		temp_buffer = temp_buffer | 0b01000000;
 	} else {
-		temp_buffer = temp_buffer & 0x10111111;
+		temp_buffer = temp_buffer & 0b10111111;
 	}
 
 	// Write the byte


### PR DESCRIPTION
Before this fix calling Clock.setClockMode(false) just wrote the same value back to register 2, and Clock.setClockMode(true) set 24h-mode and the hour to 11.

#sommerhack (https://sommerhack.dk/)