### PR TITLE
Includes for pgmspace modified so also work on ESP8266

### DIFF
--- a/DS3231.cpp
+++ b/DS3231.cpp
@@ -15,7 +15,11 @@ Released into the public domain.
 
 // These included for the DateTime class inclusion; will try to find a way to
 // not need them in the future...
+#if defined(__AVR__)
 #include <avr/pgmspace.h>
+#elif defined(ESP8266)
+#include <pgmspace.h>
+#endif
 // Changed the following to work on 1.0
 //#include "WProgram.h"
 #include <Arduino.h>


### PR DESCRIPTION
A few lines that allow the code to compile both for classic AVRs and ESP8266 platforms.

If accepted, please remember to bump ```version``` to eg. 1.0.2 in ```library.properties``` before creating the new release. Otherwise the Arduino package manager system will not pick up the new release.