### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,9 +1,9 @@
 DS3231	KEYWORD1
-RTClib KEYWORD1
-DateTime KEYWORD1
-now KEYWORD2
-secondstime KEYWORD2
-unixtime KEYWORD2
+RTClib	KEYWORD1
+DateTime	KEYWORD1
+now	KEYWORD2
+secondstime	KEYWORD2
+unixtime	KEYWORD2
 getSecond	KEYWORD2
 getMinute	KEYWORD2
 getHour	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords