### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Abstracts functionality for clock reading, clock setting, and alarms f
 category=Timing
 url=https://github.com/NorthernWidget/DS3231
 architectures=*
-includes=Wire.h
+includes=DS3231.h


### PR DESCRIPTION
The `includes` field in library.properties is used to specify which #include directives should be added to the sketch via **Sketch > Include Library > DS3231**. This field should specify the primary header file(s) of the library. Since all the Arduino IDE versions that support the `includes` field don't require `#include` directives in the sketch for library dependencies and there is already an `#include` directive for Wire.h in DS3231.h, there is no need to specify Wire.h in the `includes` field.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format