### PR TITLE
[Readme.md]: add setEpoch to the list of functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This library depends on the wire header file. To use this library functions, the
 - getDate()
 - getMonth()
 - getYear()
+- setEpoch()
 - setSecond()
 - setMinute()
 - setHour()


### PR DESCRIPTION
I forgot to add the setEpoch() to the readme file.