### PR TITLE
Fixed some Typo's in example sketch

### DIFF
--- a/examples/DS3231_oscillator_test/DS3231_oscillator_test.pde
+++ b/examples/DS3231_oscillator_test/DS3231_oscillator_test.pde
@@ -21,7 +21,7 @@ void setup() {
 	// Start the I2C interface
 	Wire.begin();
 	// Start the serial interface
-	Serial.begin(9600);
+	Serial.begin(57600);
 }
 
 void loop() {

--- a/examples/DS3231_set/DS3231_set.pde
+++ b/examples/DS3231_set/DS3231_set.pde
@@ -10,104 +10,104 @@ Test of set-time routines for a DS3231 RTC
 #include <DS3231.h>
 #include <Wire.h>
 
-DS3231 Clock;
+DS3231 clock;
 
-byte Year;
-byte Month;
-byte Date;
-byte DoW;
-byte Hour;
-byte Minute;
-byte Second;
+byte year;
+byte month;
+byte date;
+byte dOW;
+byte hour;
+byte minute;
+byte second;
 
-void GetDateStuff(byte& Year, byte& Month, byte& Day, byte& DoW, 
-		byte& Hour, byte& Minute, byte& Second) {
-	// Call this if you notice something coming in on 
-	// the serial port. The stuff coming in should be in 
-	// the order YYMMDDwHHMMSS, with an 'x' at the end.
-	boolean GotString = false;
-	char InChar;
-	byte Temp1, Temp2;
-	char InString[20];
-
-	byte j=0;
-	while (!GotString) {
-		if (Serial.available()) {
-			InChar = Serial.read();
-			InString[j] = InChar;
-			j += 1;
-			if (InChar == 'x') {
-				GotString = true;
-			}
-		}
-	}
-	Serial.println(InString);
-	// Read Year first
-	Temp1 = (byte)InString[0] -48;
-	Temp2 = (byte)InString[1] -48;
-	Year = Temp1*10 + Temp2;
-	// now month
-	Temp1 = (byte)InString[2] -48;
-	Temp2 = (byte)InString[3] -48;
-	Month = Temp1*10 + Temp2;
-	// now date
-	Temp1 = (byte)InString[4] -48;
-	Temp2 = (byte)InString[5] -48;
-	Day = Temp1*10 + Temp2;
-	// now Day of Week
-	DoW = (byte)InString[6] - 48;		
-	// now Hour
-	Temp1 = (byte)InString[7] -48;
-	Temp2 = (byte)InString[8] -48;
-	Hour = Temp1*10 + Temp2;
-	// now Minute
-	Temp1 = (byte)InString[9] -48;
-	Temp2 = (byte)InString[10] -48;
-	Minute = Temp1*10 + Temp2;
-	// now Second
-	Temp1 = (byte)InString[11] -48;
-	Temp2 = (byte)InString[12] -48;
-	Second = Temp1*10 + Temp2;
+void getDateStuff(byte& year, byte& month, byte& date, byte& dOW,
+                  byte& hour, byte& minute, byte& second) {
+    // Call this if you notice something coming in on
+    // the serial port. The stuff coming in should be in
+    // the order YYMMDDwHHMMSS, with an 'x' at the end.
+    boolean gotString = false;
+    char inChar;
+    byte temp1, temp2;
+    char inString[20];
+    
+    byte j=0;
+    while (!gotString) {
+        if (Serial.available()) {
+            inChar = Serial.read();
+            inString[j] = inChar;
+            j += 1;
+            if (inChar == 'x') {
+                gotString = true;
+            }
+        }
+    }
+    Serial.println(inString);
+    // Read year first
+    temp1 = (byte)inString[0] -48;
+    temp2 = (byte)inString[1] -48;
+    year = temp1*10 + temp2;
+    // now month
+    temp1 = (byte)inString[2] -48;
+    temp2 = (byte)inString[3] -48;
+    month = temp1*10 + temp2;
+    // now date
+    temp1 = (byte)inString[4] -48;
+    temp2 = (byte)inString[5] -48;
+    date = temp1*10 + temp2;
+    // now Day of Week
+    dOW = (byte)inString[6] - 48;
+    // now hour
+    temp1 = (byte)inString[7] -48;
+    temp2 = (byte)inString[8] -48;
+    hour = temp1*10 + temp2;
+    // now minute
+    temp1 = (byte)inString[9] -48;
+    temp2 = (byte)inString[10] -48;
+    minute = temp1*10 + temp2;
+    // now second
+    temp1 = (byte)inString[11] -48;
+    temp2 = (byte)inString[12] -48;
+    second = temp1*10 + temp2;
 }
 
 void setup() {
-	// Start the serial port
-	Serial.begin(9600);
-
-	// Start the I2C interface
-	Wire.begin();
+    // Start the serial port
+    Serial.begin(57600);
+    
+    // Start the I2C interface
+    Wire.begin();
 }
 
 void loop() {
-
-	// If something is coming in on the serial line, it's
-	// a time correction so set the clock accordingly.
-	if (Serial.available()) {
-		GetDateStuff(Year, Month, Date, DoW, Hour, Minute, Second);
-
-		Clock.setClockMode(false);	// set to 24h
-		//setClockMode(true);	// set to 12h
-
-		Clock.setYear(Year);
-		Clock.setMonth(Month);
-		Clock.setDate(Date);
-		Clock.setDoW(DoW);
-		Clock.setHour(Hour);
-		Clock.setMinute(Minute);
-		Clock.setSecond(Second);
-
-		// Test of alarm functions
-		// set A1 to one minute past the time we just set the clock
-		// on current day of week.
-		Clock.setA1Time(DoW, Hour, Minute+1, Second, 0x0, true, 
-			false, false);
-		// set A2 to two minutes past, on current day of month.
-		Clock.setA2Time(Date, Hour, Minute+2, 0x0, false, false, 
-			false);
-		// Turn on both alarms, with external interrupt
-		Clock.turnOnAlarm(1);
-		Clock.turnOnAlarm(2);
-
-	}
-	delay(1000);
+    
+    // If something is coming in on the serial line, it's
+    // a time correction so set the clock accordingly.
+    if (Serial.available()) {
+        getDateStuff(year, month, date, dOW, hour, minute, second);
+        
+        clock.setClockMode(false);  // set to 24h
+        //setClockMode(true); // set to 12h
+        
+        clock.setYear(year);
+        clock.setMonth(month);
+        clock.setDate(date);
+        clock.setDoW(dOW);
+        clock.setHour(hour);
+        clock.setMinute(minute);
+        clock.setSecond(second);
+        
+        // Test of alarm functions
+        // set A1 to one minute past the time we just set the clock
+        // on current day of week.
+        clock.setA1Time(dOW, hour, minute+1, second, 0x0, true,
+                        false, false);
+        // set A2 to two minutes past, on current day of month.
+        clock.setA2Time(date, hour, minute+2, 0x0, false, false,
+                        false);
+        // Turn on both alarms, with external interrupt
+        clock.turnOnAlarm(1);
+        clock.turnOnAlarm(2);
+        
+    }
+    delay(1000);
 }

--- a/examples/now/now.pde
+++ b/examples/now/now.pde
@@ -11,12 +11,14 @@ RTClib myRTC;
 void setup () {
     Serial.begin(57600);
     Wire.begin();
+    delay(500);
+    Serial.println("Nano Ready!");
 }
 
 void loop () {
-  
+    
     delay(1000);
-  
+    
     DateTime now = myRTC.now();
     
     Serial.print(now.year(), DEC);


### PR DESCRIPTION
DS3231_set.pde was using the word day and the word date where it should have always been the word date. It was not setting the day at all, but leaving it at zero. This has been fixed.

Also re-named variables to follow proper case convention in the same sketch.

Set all Serial.begin statements to initiate at 57600. Some examples wre starting at 57600 and others at 9600. Now they are consistent.

And in reference to your comment in DS3231.cpp where you mention the fact that if someone does a setClockMode at the right millisecond, it will set the clock back by an hour ... here is a proposed solution, which I know is not perfect, but I only wrote it to illustrate one possible way of dealing with that scenario:

This would go towards the top of the setClockMode method.

    bool h12Flag = false;
    bool pmFlag = false;
	byte h = getHour(h12Flag,pmFlag);
	byte m = getMinute();
	byte s = getSecond();
	int diff = 59 - s;
	if (h == 11 || h == 23) {
	    if (m == 59) {
	        if (diff <= 3) {
	            delay(3500);
	        }
	    }
	}

All it does is check to see if the clock is close to that moment, then if it is, it simply waits to make sure that moment has passed before issuing the setting.