### PR TITLE
Allow use of secondary i2c bus

### DIFF
--- a/DS3231.cpp
+++ b/DS3231.cpp
@@ -22,7 +22,7 @@ David Merrifield
 Released into the public domain.
 */
 
-#include <DS3231.h>
+#include "DS3231.h"
 
 // These included for the DateTime class inclusion; will try to find a way to
 // not need them in the future...
@@ -42,8 +42,11 @@ Released into the public domain.
 
 
 // Constructor
-DS3231::DS3231() {
+DS3231::DS3231() : _Wire(Wire) {
 	// nothing to do for this constructor.
+}
+
+DS3231::DS3231(TwoWire & w) : _Wire(w) {
 }
 
 // Utilities from JeeLabs/Ladyada
@@ -159,20 +162,20 @@ bool isleapYear(const uint8_t y) {
   return (y % 100 || y % 400 == 0);
 }
 
-DateTime RTClib::now() {
-  Wire.beginTransmission(CLOCK_ADDRESS);
-  Wire.write(0);	// This is the first register address (Seconds)
+DateTime RTClib::now(TwoWire & _Wire) {
+  _Wire.beginTransmission(CLOCK_ADDRESS);
+  _Wire.write(0);	// This is the first register address (Seconds)
   			// We'll read from here on for 7 bytes: secs reg, minutes reg, hours, days, months and years.
-  Wire.endTransmission();
+  _Wire.endTransmission();
   
-  Wire.requestFrom(CLOCK_ADDRESS, 7);
-  uint16_t ss = bcd2bin(Wire.read() & 0x7F);
-  uint16_t mm = bcd2bin(Wire.read());
-  uint16_t hh = bcd2bin(Wire.read());
-  Wire.read();
-  uint16_t d = bcd2bin(Wire.read());
-  uint16_t m = bcd2bin(Wire.read());
-  uint16_t y = bcd2bin(Wire.read()) + 2000;
+  _Wire.requestFrom(CLOCK_ADDRESS, 7);
+  uint16_t ss = bcd2bin(_Wire.read() & 0x7F);
+  uint16_t mm = bcd2bin(_Wire.read());
+  uint16_t hh = bcd2bin(_Wire.read());
+  _Wire.read();
+  uint16_t d = bcd2bin(_Wire.read());
+  uint16_t m = bcd2bin(_Wire.read());
+  uint16_t y = bcd2bin(_Wire.read()) + 2000;
   
   return DateTime (y, m, d, hh, mm, ss);
 }
@@ -180,32 +183,32 @@ DateTime RTClib::now() {
 ///// ERIC'S ORIGINAL CODE FOLLOWS /////
 
 byte DS3231::getSecond() {
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x00);
-	Wire.endTransmission();
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x00);
+	_Wire.endTransmission();
 
-	Wire.requestFrom(CLOCK_ADDRESS, 1);
-	return bcdToDec(Wire.read());
+	_Wire.requestFrom(CLOCK_ADDRESS, 1);
+	return bcdToDec(_Wire.read());
 }
 
 byte DS3231::getMinute() {
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x01);
-	Wire.endTransmission();
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x01);
+	_Wire.endTransmission();
 
-	Wire.requestFrom(CLOCK_ADDRESS, 1);
-	return bcdToDec(Wire.read());
+	_Wire.requestFrom(CLOCK_ADDRESS, 1);
+	return bcdToDec(_Wire.read());
 }
 
 byte DS3231::getHour(bool& h12, bool& PM_time) {
 	byte temp_buffer;
 	byte hour;
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x02);
-	Wire.endTransmission();
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x02);
+	_Wire.endTransmission();
 
-	Wire.requestFrom(CLOCK_ADDRESS, 1);
-	temp_buffer = Wire.read();
+	_Wire.requestFrom(CLOCK_ADDRESS, 1);
+	temp_buffer = _Wire.read();
 	h12 = temp_buffer & 0b01000000;
 	if (h12) {
 		PM_time = temp_buffer & 0b00100000;
@@ -217,42 +220,42 @@ byte DS3231::getHour(bool& h12, bool& PM_time) {
 }
 
 byte DS3231::getDoW() {
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x03);
-	Wire.endTransmission();
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x03);
+	_Wire.endTransmission();
 
-	Wire.requestFrom(CLOCK_ADDRESS, 1);
-	return bcdToDec(Wire.read());
+	_Wire.requestFrom(CLOCK_ADDRESS, 1);
+	return bcdToDec(_Wire.read());
 }
 
 byte DS3231::getDate() {
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x04);
-	Wire.endTransmission();
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x04);
+	_Wire.endTransmission();
 
-	Wire.requestFrom(CLOCK_ADDRESS, 1);
-	return bcdToDec(Wire.read());
+	_Wire.requestFrom(CLOCK_ADDRESS, 1);
+	return bcdToDec(_Wire.read());
 }
 
 byte DS3231::getMonth(bool& Century) {
 	byte temp_buffer;
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x05);
-	Wire.endTransmission();
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x05);
+	_Wire.endTransmission();
 
-	Wire.requestFrom(CLOCK_ADDRESS, 1);
-	temp_buffer = Wire.read();
+	_Wire.requestFrom(CLOCK_ADDRESS, 1);
+	temp_buffer = _Wire.read();
 	Century = temp_buffer & 0b10000000;
 	return (bcdToDec(temp_buffer & 0b01111111)) ;
 }
 
 byte DS3231::getYear() {
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x06);
-	Wire.endTransmission();
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x06);
+	_Wire.endTransmission();
 
-	Wire.requestFrom(CLOCK_ADDRESS, 1);
-	return bcdToDec(Wire.read());
+	_Wire.requestFrom(CLOCK_ADDRESS, 1);
+	return bcdToDec(_Wire.read());
 }
 
 // setEpoch function gives the epoch as parameter and feeds the RTC
@@ -278,10 +281,10 @@ void DS3231::setSecond(byte Second) {
 	// Sets the seconds 
 	// This function also resets the Oscillator Stop Flag, which is set
 	// whenever power is interrupted.
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x00);
-	Wire.write(decToBcd(Second));	
-	Wire.endTransmission();
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x00);
+	_Wire.write(decToBcd(Second));	
+	_Wire.endTransmission();
 	// Clear OSF flag
 	byte temp_buffer = readControlByte(1);
 	writeControlByte((temp_buffer & 0b01111111), 1);
@@ -289,10 +292,10 @@ void DS3231::setSecond(byte Second) {
 
 void DS3231::setMinute(byte Minute) {
 	// Sets the minutes 
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x01);
-	Wire.write(decToBcd(Minute));	
-	Wire.endTransmission();
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x01);
+	_Wire.write(decToBcd(Minute));	
+	_Wire.endTransmission();
 }
 
 // Following setHour revision by David Merrifield 4/14/2020 correcting handling of 12-hour clock
@@ -305,11 +308,11 @@ void DS3231::setHour(byte Hour) {
 	byte temp_hour;
 
 	// Start by figuring out what the 12/24 mode is
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x02);
-	Wire.endTransmission();
-	Wire.requestFrom(CLOCK_ADDRESS, 1);
-	h12 = (Wire.read() & 0b01000000);
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x02);
+	_Wire.endTransmission();
+	_Wire.requestFrom(CLOCK_ADDRESS, 1);
+	h12 = (_Wire.read() & 0b01000000);
 	// if h12 is true, it's 12h mode; false is 24h.
 
 	if (h12) {
@@ -328,42 +331,42 @@ void DS3231::setHour(byte Hour) {
 		temp_hour = decToBcd(Hour) & 0b10111111;
 	}
 
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x02);
-	Wire.write(temp_hour);
-	Wire.endTransmission();
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x02);
+	_Wire.write(temp_hour);
+	_Wire.endTransmission();
 }
 
 void DS3231::setDoW(byte DoW) {
 	// Sets the Day of Week
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x03);
-	Wire.write(decToBcd(DoW));	
-	Wire.endTransmission();
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x03);
+	_Wire.write(decToBcd(DoW));	
+	_Wire.endTransmission();
 }
 
 void DS3231::setDate(byte Date) {
 	// Sets the Date
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x04);
-	Wire.write(decToBcd(Date));	
-	Wire.endTransmission();
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x04);
+	_Wire.write(decToBcd(Date));	
+	_Wire.endTransmission();
 }
 
 void DS3231::setMonth(byte Month) {
 	// Sets the month
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x05);
-	Wire.write(decToBcd(Month));	
-	Wire.endTransmission();
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x05);
+	_Wire.write(decToBcd(Month));	
+	_Wire.endTransmission();
 }
 
 void DS3231::setYear(byte Year) {
 	// Sets the year
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x06);
-	Wire.write(decToBcd(Year));	
-	Wire.endTransmission();
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x06);
+	_Wire.write(decToBcd(Year));	
+	_Wire.endTransmission();
 }
 
 void DS3231::setClockMode(bool h12) {
@@ -379,11 +382,11 @@ void DS3231::setClockMode(bool h12) {
 	byte temp_buffer;
 
 	// Start by reading byte 0x02.
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x02);
-	Wire.endTransmission();
-	Wire.requestFrom(CLOCK_ADDRESS, 1);
-	temp_buffer = Wire.read();
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x02);
+	_Wire.endTransmission();
+	_Wire.requestFrom(CLOCK_ADDRESS, 1);
+	temp_buffer = _Wire.read();
 
 	// Set the flag to the requested value:
 	if (h12) {
@@ -393,10 +396,10 @@ void DS3231::setClockMode(bool h12) {
 	}
 
 	// Write the byte
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x02);
-	Wire.write(temp_buffer);
-	Wire.endTransmission();
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x02);
+	_Wire.write(temp_buffer);
+	_Wire.endTransmission();
 }
 
 float DS3231::getTemperature() {
@@ -410,15 +413,15 @@ float DS3231::getTemperature() {
   float temp3231;
   
   // temp registers (11h-12h) get updated automatically every 64s
-  Wire.beginTransmission(CLOCK_ADDRESS);
-  Wire.write(0x11);
-  Wire.endTransmission();
-  Wire.requestFrom(CLOCK_ADDRESS, 2);
+  _Wire.beginTransmission(CLOCK_ADDRESS);
+  _Wire.write(0x11);
+  _Wire.endTransmission();
+  _Wire.requestFrom(CLOCK_ADDRESS, 2);
 
   // Should I do more "if available" checks here?
-  if(Wire.available()) {
-    tMSB = Wire.read(); //2's complement int portion
-    tLSB = Wire.read(); //fraction portion
+  if(_Wire.available()) {
+    tMSB = _Wire.read(); //2's complement int portion
+    tLSB = _Wire.read(); //fraction portion
 
     int16_t  itemp  = ( tMSB << 8 | (tLSB & 0xC0) );  // Shift upper byte, add lower
     temp3231 = ( (float)itemp / 256.0 );              // Scale and return
@@ -432,23 +435,23 @@ float DS3231::getTemperature() {
 
 void DS3231::getA1Time(byte& A1Day, byte& A1Hour, byte& A1Minute, byte& A1Second, byte& AlarmBits, bool& A1Dy, bool& A1h12, bool& A1PM) {
 	byte temp_buffer;
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x07);
-	Wire.endTransmission();
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x07);
+	_Wire.endTransmission();
 
-	Wire.requestFrom(CLOCK_ADDRESS, 4);
+	_Wire.requestFrom(CLOCK_ADDRESS, 4);
 
-	temp_buffer	= Wire.read();	// Get A1M1 and A1 Seconds
+	temp_buffer	= _Wire.read();	// Get A1M1 and A1 Seconds
 	A1Second	= bcdToDec(temp_buffer & 0b01111111);
 	// put A1M1 bit in position 0 of DS3231_AlarmBits.
 	AlarmBits	= AlarmBits | (temp_buffer & 0b10000000)>>7;
 
-	temp_buffer		= Wire.read();	// Get A1M2 and A1 minutes
+	temp_buffer		= _Wire.read();	// Get A1M2 and A1 minutes
 	A1Minute	= bcdToDec(temp_buffer & 0b01111111);
 	// put A1M2 bit in position 1 of DS3231_AlarmBits.
 	AlarmBits	= AlarmBits | (temp_buffer & 0b10000000)>>6;
 
-	temp_buffer	= Wire.read();	// Get A1M3 and A1 Hour
+	temp_buffer	= _Wire.read();	// Get A1M3 and A1 Hour
 	// put A1M3 bit in position 2 of DS3231_AlarmBits.
 	AlarmBits	= AlarmBits | (temp_buffer & 0b10000000)>>5;
 	// determine A1 12/24 mode
@@ -460,7 +463,7 @@ void DS3231::getA1Time(byte& A1Day, byte& A1Hour, byte& A1Minute, byte& A1Second
 		A1Hour	= bcdToDec(temp_buffer & 0b00111111);	// 24-hour
 	}
 
-	temp_buffer	= Wire.read();	// Get A1M4 and A1 Day/Date
+	temp_buffer	= _Wire.read();	// Get A1M4 and A1 Day/Date
 	// put A1M3 bit in position 3 of DS3231_AlarmBits.
 	AlarmBits	= AlarmBits | (temp_buffer & 0b10000000)>>4;
 	// determine A1 day or date flag
@@ -476,17 +479,17 @@ void DS3231::getA1Time(byte& A1Day, byte& A1Hour, byte& A1Minute, byte& A1Second
 
 void DS3231::getA2Time(byte& A2Day, byte& A2Hour, byte& A2Minute, byte& AlarmBits, bool& A2Dy, bool& A2h12, bool& A2PM) {
 	byte temp_buffer;
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x0b);
-	Wire.endTransmission();
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x0b);
+	_Wire.endTransmission();
 
-	Wire.requestFrom(CLOCK_ADDRESS, 3); 
-	temp_buffer	= Wire.read();	// Get A2M2 and A2 Minutes
+	_Wire.requestFrom(CLOCK_ADDRESS, 3); 
+	temp_buffer	= _Wire.read();	// Get A2M2 and A2 Minutes
 	A2Minute	= bcdToDec(temp_buffer & 0b01111111);
 	// put A2M2 bit in position 4 of DS3231_AlarmBits.
 	AlarmBits	= AlarmBits | (temp_buffer & 0b10000000)>>3;
 
-	temp_buffer	= Wire.read();	// Get A2M3 and A2 Hour
+	temp_buffer	= _Wire.read();	// Get A2M3 and A2 Hour
 	// put A2M3 bit in position 5 of DS3231_AlarmBits.
 	AlarmBits	= AlarmBits | (temp_buffer & 0b10000000)>>2;
 	// determine A2 12/24 mode
@@ -498,7 +501,7 @@ void DS3231::getA2Time(byte& A2Day, byte& A2Hour, byte& A2Minute, byte& AlarmBit
 		A2Hour	= bcdToDec(temp_buffer & 0b00111111);	// 24-hour
 	}
 
-	temp_buffer	= Wire.read();	// Get A2M4 and A1 Day/Date
+	temp_buffer	= _Wire.read();	// Get A2M4 and A1 Day/Date
 	// put A2M4 bit in position 6 of DS3231_AlarmBits.
 	AlarmBits	= AlarmBits | (temp_buffer & 0b10000000)>>1;
 	// determine A2 day or date flag
@@ -515,12 +518,12 @@ void DS3231::getA2Time(byte& A2Day, byte& A2Hour, byte& A2Minute, byte& AlarmBit
 void DS3231::setA1Time(byte A1Day, byte A1Hour, byte A1Minute, byte A1Second, byte AlarmBits, bool A1Dy, bool A1h12, bool A1PM) {
 	//	Sets the alarm-1 date and time on the DS3231, using A1* information
 	byte temp_buffer;
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x07);	// A1 starts at 07h
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x07);	// A1 starts at 07h
 	// Send A1 second and A1M1
-	Wire.write(decToBcd(A1Second) | ((AlarmBits & 0b00000001) << 7));
+	_Wire.write(decToBcd(A1Second) | ((AlarmBits & 0b00000001) << 7));
 	// Send A1 Minute and A1M2
-	Wire.write(decToBcd(A1Minute) | ((AlarmBits & 0b00000010) << 6));
+	_Wire.write(decToBcd(A1Minute) | ((AlarmBits & 0b00000010) << 6));
 	// Figure out A1 hour 
 	if (A1h12) {
 		// Start by converting existing time to h12 if it was given in 24h.
@@ -544,25 +547,25 @@ void DS3231::setA1Time(byte A1Day, byte A1Hour, byte A1Minute, byte A1Second, by
 	}
 	temp_buffer = temp_buffer | ((AlarmBits & 0b00000100)<<5);
 	// A1 hour is figured out, send it
-	Wire.write(temp_buffer); 
+	_Wire.write(temp_buffer); 
 	// Figure out A1 day/date and A1M4
 	temp_buffer = ((AlarmBits & 0b00001000)<<4) | decToBcd(A1Day);
 	if (A1Dy) {
 		// Set A1 Day/Date flag (Otherwise it's zero)
 		temp_buffer = temp_buffer | 0b01000000;
 	}
-	Wire.write(temp_buffer);
+	_Wire.write(temp_buffer);
 	// All done!
-	Wire.endTransmission();
+	_Wire.endTransmission();
 }
 
 void DS3231::setA2Time(byte A2Day, byte A2Hour, byte A2Minute, byte AlarmBits, bool A2Dy, bool A2h12, bool A2PM) {
 	//	Sets the alarm-2 date and time on the DS3231, using A2* information
 	byte temp_buffer;
-	Wire.beginTransmission(CLOCK_ADDRESS);
-	Wire.write(0x0b);	// A1 starts at 0bh
+	_Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.write(0x0b);	// A1 starts at 0bh
 	// Send A2 Minute and A2M2
-	Wire.write(decToBcd(A2Minute) | ((AlarmBits & 0b00010000) << 3));
+	_Wire.write(decToBcd(A2Minute) | ((AlarmBits & 0b00010000) << 3));
 	// Figure out A2 hour 
 	if (A2h12) {
 		// Start by converting existing time to h12 if it was given in 24h.
@@ -587,16 +590,16 @@ void DS3231::setA2Time(byte A2Day, byte A2Hour, byte A2Minute, byte AlarmBits, b
 	// add in A2M3 bit
 	temp_buffer = temp_buffer | ((AlarmBits & 0b00100000)<<2);
 	// A2 hour is figured out, send it
-	Wire.write(temp_buffer); 
+	_Wire.write(temp_buffer); 
 	// Figure out A2 day/date and A2M4
 	temp_buffer = ((AlarmBits & 0b01000000)<<1) | decToBcd(A2Day);
 	if (A2Dy) {
 		// Set A2 Day/Date flag (Otherwise it's zero)
 		temp_buffer = temp_buffer | 0b01000000;
 	}
-	Wire.write(temp_buffer);
+	_Wire.write(temp_buffer);
 	// All done!
-	Wire.endTransmission();
+	_Wire.endTransmission();
 }
 
 void DS3231::turnOnAlarm(byte Alarm) {
@@ -732,29 +735,29 @@ byte DS3231::bcdToDec(byte val) {
 byte DS3231::readControlByte(bool which) {
 	// Read selected control byte
 	// first byte (0) is 0x0e, second (1) is 0x0f
-	Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.beginTransmission(CLOCK_ADDRESS);
 	if (which) {
 		// second control byte
-		Wire.write(0x0f);
+		_Wire.write(0x0f);
 	} else {
 		// first control byte
-		Wire.write(0x0e);
+		_Wire.write(0x0e);
 	}
-	Wire.endTransmission();
-	Wire.requestFrom(CLOCK_ADDRESS, 1);
-	return Wire.read();	
+	_Wire.endTransmission();
+	_Wire.requestFrom(CLOCK_ADDRESS, 1);
+	return _Wire.read();	
 }
 
 void DS3231::writeControlByte(byte control, bool which) {
 	// Write the selected control byte.
 	// which=false -> 0x0e, true->0x0f.
-	Wire.beginTransmission(CLOCK_ADDRESS);
+	_Wire.beginTransmission(CLOCK_ADDRESS);
 	if (which) {
-		Wire.write(0x0f);
+		_Wire.write(0x0f);
 	} else {
-		Wire.write(0x0e);
+		_Wire.write(0x0e);
 	}
-	Wire.write(control);
-	Wire.endTransmission();
+	_Wire.write(control);
+	_Wire.endTransmission();
 }
 

--- a/DS3231.h
+++ b/DS3231.h
@@ -66,7 +66,7 @@ class DS3231 {
 		DS3231();
 		DS3231(TwoWire & w);
 
-	  TwoWire & _Wire;
+		TwoWire & _Wire;
 
 		// Time-retrieval functions
     

--- a/DS3231.h
+++ b/DS3231.h
@@ -55,7 +55,7 @@ bool isleapYear(const uint8_t);
 class RTClib {
   public:
 		// Get date and time snapshot
-    static DateTime now();
+    static DateTime now(TwoWire & _Wire = Wire);
 };
 
 // Eric's original code is everything below this line
@@ -64,6 +64,9 @@ class DS3231 {
 			
 		//Constructor
 		DS3231();
+		DS3231(TwoWire & w);
+
+	  TwoWire & _Wire;
 
 		// Time-retrieval functions
     


### PR DESCRIPTION
This PR maintains backward compatibility while adding the ability to specify a non-default TwoWire object like Wire2, Wire3, etc...  Tested on Adafruit Feather M0 express.

No changes are required to use the default Wire object.

To specify a non-default Wire object, pass it to the constructor like this:

```DS3231 ds3231(Wire2);```