### PR TITLE
Fix datetime parsing

### DIFF
--- a/DS3231.cpp
+++ b/DS3231.cpp
@@ -132,10 +132,10 @@ DateTime::DateTime(const char* date, const char* time) {
    static const char month_names[] = "JanFebMarAprMayJunJulAugSepOctNovDec";
    static char buff[4] = {'0','0','0','0'};
    int y;
-   sscanf(date, "%s %c %d", buff, &d, &y);
+   sscanf(date, "%s %hhu %d", buff, &d, &y);
    yOff = y >= 2000 ? y - 2000 : y;
    m = (strstr(month_names, buff) - month_names) / 3 + 1;
-   sscanf(time, "%c:%c:%c", &hh, &mm, &ss);
+   sscanf(time, "%hhu:%hhu:%hhu", &hh, &mm, &ss);
 }
 
 // UNIX time: IS CORRECT ONLY WHEN SET TO UTC!!!


### PR DESCRIPTION
Parsing \_\_DATE\_\_ and \_\_TIME\_\_ does not work right now, this PR fixes it.

Current parsing tries to parse double digits as a character which only takes the first digit. It used to work before this commit: https://github.com/NorthernWidget/DS3231/commit/c15b45025691f90caceb793480b62132886742eb
But the scanf string wasn't correct before either, as it used `%d` for `uint8_t`, while `%d` should be used for `int`. The correct specifier for `uint8_t` would be `%hhu` as per https://www.cplusplus.com/reference/cstdio/scanf/