### PR TITLE
variable "clock" conflict

### DIFF
--- a/examples/DS3231_oscillator_test/DS3231_oscillator_test.pde
+++ b/examples/DS3231_oscillator_test/DS3231_oscillator_test.pde
@@ -13,7 +13,7 @@ working as they should.
 #include <DS3231.h>
 #include <Wire.h>
 
-DS3231 Clock;
+DS3231 myRTC;
 byte j;
 bool on = false;
 
@@ -28,9 +28,9 @@ void loop() {
 	for (j=0;j<4;j++) {
 		// invert state of 32kHz oscillator.
 		on = !on;
-		Clock.enable32kHz(on);
+		myRTC.enable32kHz(on);
 		// Turn on oscillator pin, frequency j
-		Clock.enableOscillator(true, false, j);
+		myRTC.enableOscillator(true, false, j);
 		delay(4000);
 	}
 	// So... The 32kHz oscillator (pin 1) will turn on or off once each 2s,

--- a/examples/DS3231_set/DS3231_set.pde
+++ b/examples/DS3231_set/DS3231_set.pde
@@ -10,7 +10,7 @@ Test of set-time routines for a DS3231 RTC
 #include <DS3231.h>
 #include <Wire.h>
 
-DS3231 clock;
+DS3231 myRTC;
 
 byte year;
 byte month;
@@ -85,28 +85,28 @@ void loop() {
     if (Serial.available()) {
         getDateStuff(year, month, date, dOW, hour, minute, second);
         
-        clock.setClockMode(false);  // set to 24h
+        myRTC.setClockMode(false);  // set to 24h
         //setClockMode(true); // set to 12h
         
-        clock.setYear(year);
-        clock.setMonth(month);
-        clock.setDate(date);
-        clock.setDoW(dOW);
-        clock.setHour(hour);
-        clock.setMinute(minute);
-        clock.setSecond(second);
+        myRTC.setYear(year);
+        myRTC.setMonth(month);
+        myRTC.setDate(date);
+        myRTC.setDoW(dOW);
+        myRTC.setHour(hour);
+        myRTC.setMinute(minute);
+        myRTC.setSecond(second);
         
         // Test of alarm functions
         // set A1 to one minute past the time we just set the clock
         // on current day of week.
-        clock.setA1Time(dOW, hour, minute+1, second, 0x0, true,
+        myRTC.setA1Time(dOW, hour, minute+1, second, 0x0, true,
                         false, false);
         // set A2 to two minutes past, on current day of month.
-        clock.setA2Time(date, hour, minute+2, 0x0, false, false,
+        myRTC.setA2Time(date, hour, minute+2, 0x0, false, false,
                         false);
         // Turn on both alarms, with external interrupt
-        clock.turnOnAlarm(1);
-        clock.turnOnAlarm(2);
+        myRTC.turnOnAlarm(1);
+        myRTC.turnOnAlarm(2);
         
     }
     delay(1000);

--- a/examples/DS3231_test/DS3231_test.pde
+++ b/examples/DS3231_test/DS3231_test.pde
@@ -13,7 +13,7 @@ working as they should.
 #include <DS3231.h>
 #include <Wire.h>
 
-DS3231 clock;
+DS3231 myRTC;
 bool century = false;
 bool h12Flag;
 bool pmFlag;
@@ -38,27 +38,27 @@ void loop() {
 	} else {
 		Serial.print("0");
 	}
-	Serial.print(clock.getYear(), DEC);
+	Serial.print(myRTC.getYear(), DEC);
 	Serial.print(' ');
 	
 	// then the month
-	Serial.print(clock.getMonth(century), DEC);
+	Serial.print(myRTC.getMonth(century), DEC);
 	Serial.print(" ");
   
 	// then the date
-	Serial.print(clock.getDate(), DEC);
+	Serial.print(myRTC.getDate(), DEC);
 	Serial.print(" ");
   
 	// and the day of the week
-	Serial.print(clock.getDoW(), DEC);
+	Serial.print(myRTC.getDoW(), DEC);
 	Serial.print(" ");
   
 	// Finally the hour, minute, and second
-	Serial.print(clock.getHour(h12Flag, pmFlag), DEC);
+	Serial.print(myRTC.getHour(h12Flag, pmFlag), DEC);
 	Serial.print(" ");
-	Serial.print(clock.getMinute(), DEC);
+	Serial.print(myRTC.getMinute(), DEC);
 	Serial.print(" ");
-	Serial.print(clock.getSecond(), DEC);
+	Serial.print(myRTC.getSecond(), DEC);
  
 	// Add AM/PM indicator
 	if (h12Flag) {
@@ -73,21 +73,21 @@ void loop() {
  
 	// Display the temperature
 	Serial.print("T=");
-	Serial.print(clock.getTemperature(), 2);
+	Serial.print(myRTC.getTemperature(), 2);
   
 	// Tell whether the time is (likely to be) valid
-	if (clock.oscillatorCheck()) {
+	if (myRTC.oscillatorCheck()) {
 		Serial.print(" O+");
 	} else {
 		Serial.print(" O-");
 	}
  
 	// Indicate whether an alarm went off
-	if (clock.checkIfAlarm(1)) {
+	if (myRTC.checkIfAlarm(1)) {
 		Serial.print(" A1!");
 	}
  
-	if (clock.checkIfAlarm(2)) {
+	if (myRTC.checkIfAlarm(2)) {
 		Serial.print(" A2!");
 	}
  
@@ -96,7 +96,7 @@ void loop() {
 	
 	// Display Alarm 1 information
 	Serial.print("Alarm 1: ");
-	clock.getA1Time(alarmDay, alarmHour, alarmMinute, alarmSecond, alarmBits, alarmDy, alarmH12Flag, alarmPmFlag);
+	myRTC.getA1Time(alarmDay, alarmHour, alarmMinute, alarmSecond, alarmBits, alarmDy, alarmH12Flag, alarmPmFlag);
 	Serial.print(alarmDay, DEC);
 	if (alarmDy) {
 		Serial.print(" DoW");
@@ -117,14 +117,14 @@ void loop() {
 			Serial.print("am ");
 		}
 	}
-	if (clock.checkAlarmEnabled(1)) {
+	if (myRTC.checkAlarmEnabled(1)) {
 		Serial.print("enabled");
 	}
 	Serial.println();
  
 	// Display Alarm 2 information
 	Serial.print("Alarm 2: ");
-	clock.getA2Time(alarmDay, alarmHour, alarmMinute, alarmBits, alarmDy, alarmH12Flag, alarmPmFlag);
+	myRTC.getA2Time(alarmDay, alarmHour, alarmMinute, alarmBits, alarmDy, alarmH12Flag, alarmPmFlag);
 	Serial.print(alarmDay, DEC);
 	if (alarmDy) {
 		Serial.print(" DoW");
@@ -143,7 +143,7 @@ void loop() {
 			Serial.print("am");
 		}
 	}
-	if (clock.checkAlarmEnabled(2)) {
+	if (myRTC.checkAlarmEnabled(2)) {
 		Serial.print("enabled");
 	}
  

--- a/examples/echo_time/echo_time.pde
+++ b/examples/echo_time/echo_time.pde
@@ -16,7 +16,7 @@ Andy Wickert
 #include <DS3231.h>
 #include <Wire.h>
 
-DS3231 clock;
+DS3231 myRTC;
 
 bool century = false;
 bool h12Flag;
@@ -32,17 +32,17 @@ void setup() {
 
   for (int i=0; i<5; i++){
       delay(1000);
-      Serial.print(clock.getYear(), DEC);
+      Serial.print(myRTC.getYear(), DEC);
       Serial.print("-");
-      Serial.print(clock.getMonth(century), DEC);
+      Serial.print(myRTC.getMonth(century), DEC);
       Serial.print("-");
-      Serial.print(clock.getDate(), DEC);
+      Serial.print(myRTC.getDate(), DEC);
       Serial.print(" ");
-      Serial.print(clock.getHour(h12Flag, pmFlag), DEC); //24-hr
+      Serial.print(myRTC.getHour(h12Flag, pmFlag), DEC); //24-hr
       Serial.print(":");
-      Serial.print(clock.getMinute(), DEC);
+      Serial.print(myRTC.getMinute(), DEC);
       Serial.print(":");
-      Serial.println(clock.getSecond(), DEC);
+      Serial.println(myRTC.getSecond(), DEC);
   }
 }
 


### PR DESCRIPTION
Due to the error  
_'DS3231 clock' redeclared as different kind of symbol_
 and to make all the examples more consistent, I change the variable **clock** to **myRTC** in every example code.