### PR TITLE
#51

### DIFF
--- a/DS3231.cpp
+++ b/DS3231.cpp
@@ -477,6 +477,13 @@ void DS3231::getA1Time(byte& A1Day, byte& A1Hour, byte& A1Minute, byte& A1Second
 	}
 }
 
+void DS3231::getA1Time(byte& A1Day, byte& A1Hour, byte& A1Minute, byte& A1Second, byte& AlarmBits, bool& A1Dy, bool& A1h12, bool& A1PM, bool& clearAlarmBits) {
+    if (clearAlarmBits) {
+        AlarmBits = 0x0;
+    }
+    getA1Time(A1Day, A1Hour, A1Minute, A1Second, AlarmBits, A1Dy, A1h12, A1PM);
+}
+
 void DS3231::getA2Time(byte& A2Day, byte& A2Hour, byte& A2Minute, byte& AlarmBits, bool& A2Dy, bool& A2h12, bool& A2PM) {
 	byte temp_buffer;
 	_Wire.beginTransmission(CLOCK_ADDRESS);
@@ -513,6 +520,13 @@ void DS3231::getA2Time(byte& A2Day, byte& A2Hour, byte& A2Minute, byte& AlarmBit
 		// alarm is by date, not day of week.
 		A2Day	= bcdToDec(temp_buffer & 0b00111111);
 	}
+}
+
+void DS3231::getA2Time(byte& A2Day, byte& A2Hour, byte& A2Minute, byte& AlarmBits, bool& A2Dy, bool& A2h12, bool& A2PM, bool& clearAlarmBits) {
+    if (clearAlarmBits) {
+        AlarmBits = 0x0;
+    }
+    getA2Time(A2Day, A2Hour, A2Minute, AlarmBits, A2Dy, A2h12, A2PM);
 }
 
 void DS3231::setA1Time(byte A1Day, byte A1Hour, byte A1Minute, byte A1Second, byte AlarmBits, bool A1Dy, bool A1h12, bool A1PM) {

--- a/DS3231.cpp
+++ b/DS3231.cpp
@@ -477,6 +477,13 @@ void DS3231::getA1Time(byte& A1Day, byte& A1Hour, byte& A1Minute, byte& A1Second
 	}
 }
 
+void DS3231::getA1Time(byte& A1Day, byte& A1Hour, byte& A1Minute, byte& A1Second, byte& AlarmBits, bool& A1Dy, bool& A1h12, bool& A1PM, bool clearAlarmBits) {
+    if (clearAlarmBits) {
+        AlarmBits = 0x0;
+    }
+    getA1Time(A1Day, A1Hour, A1Minute, A1Second, AlarmBits, A1Dy, A1h12, A1PM);
+}
+
 void DS3231::getA2Time(byte& A2Day, byte& A2Hour, byte& A2Minute, byte& AlarmBits, bool& A2Dy, bool& A2h12, bool& A2PM) {
 	byte temp_buffer;
 	_Wire.beginTransmission(CLOCK_ADDRESS);
@@ -513,6 +520,13 @@ void DS3231::getA2Time(byte& A2Day, byte& A2Hour, byte& A2Minute, byte& AlarmBit
 		// alarm is by date, not day of week.
 		A2Day	= bcdToDec(temp_buffer & 0b00111111);
 	}
+}
+
+void DS3231::getA2Time(byte& A2Day, byte& A2Hour, byte& A2Minute, byte& AlarmBits, bool& A2Dy, bool& A2h12, bool& A2PM, bool clearAlarmBits) {
+    if (clearAlarmBits) {
+        AlarmBits = 0x0;
+    }
+    getA2Time(A2Day, A2Hour, A2Minute, AlarmBits, A2Dy, A2h12, A2PM);
 }
 
 void DS3231::setA1Time(byte A1Day, byte A1Hour, byte A1Minute, byte A1Second, byte AlarmBits, bool A1Dy, bool A1h12, bool A1PM) {

--- a/DS3231.h
+++ b/DS3231.h
@@ -137,11 +137,17 @@ class DS3231 {
  *	0	0		0		0		Alarm when date, hour, min match
  *	1	0		0		0		Alarm when DoW, hour, min match
  *
- *	Note: byte AlarmBits is not cleared for the getAXTime methods to support
- *	sequential retreival of both alarms with the same byte AlarmBits.
+ *	Note: byte AlarmBits is not explicitly cleared for the getAXTime methods to
+ *	support sequential retreival of both alarms with the same byte AlarmBits.
+ *	Use the flag bool clearAlarmBits=True to explicitly clear byte AlarmBits on
+ *  call to getAXTime.
  */
 		void getA2Time(byte& A2Day, byte& A2Hour, byte& A2Minute, byte& AlarmBits, bool& A2Dy, bool& A2h12, bool& A2PM);
 			// Same as getA1Time();, but A2 only goes on seconds == 00.
+		void getA1Time(byte& A1Day, byte& A1Hour, byte& A1Minute, byte& A1Second, byte& AlarmBits, bool& A1Dy, bool& A1h12, bool& A1PM, bool clearAlarmBits);
+			// Same as getA1Time();, but clears byte AlarmBits.
+		void getA2Time(byte& A1Day, byte& A1Hour, byte& A1Minute,byte& AlarmBits, bool& A1Dy, bool& A1h12, bool& A1PM, bool clearAlarmBits);
+			// Same as getA1Time();, but clears byte AlarmBits.
 		void setA1Time(byte A1Day, byte A1Hour, byte A1Minute, byte A1Second, byte AlarmBits, bool A1Dy, bool A1h12, bool A1PM);
 			// Set the details for Alarm 1
 		void setA2Time(byte A2Day, byte A2Hour, byte A2Minute, byte AlarmBits, bool A2Dy, bool A2h12, bool A2PM);

--- a/DS3231.h
+++ b/DS3231.h
@@ -136,6 +136,9 @@ class DS3231 {
  *	X	1		0		0		Alarm when hours and minutes match
  *	0	0		0		0		Alarm when date, hour, min match
  *	1	0		0		0		Alarm when DoW, hour, min match
+ *
+ *	Note: byte AlarmBits is not cleared for the getAXTime methods to support
+ *	sequential retreival of both alarms with the same byte AlarmBits.
  */
 		void getA2Time(byte& A2Day, byte& A2Hour, byte& A2Minute, byte& AlarmBits, bool& A2Dy, bool& A2h12, bool& A2PM);
 			// Same as getA1Time();, but A2 only goes on seconds == 00.

--- a/DS3231.h
+++ b/DS3231.h
@@ -137,11 +137,17 @@ class DS3231 {
  *	0	0		0		0		Alarm when date, hour, min match
  *	1	0		0		0		Alarm when DoW, hour, min match
  *
- *	Note: byte AlarmBits is not cleared for the getAXTime methods to support
- *	sequential retreival of both alarms with the same byte AlarmBits.
+ *	Note: byte AlarmBits is not explicitly cleared for the getAXTime methods to
+ *	support sequential retreival of both alarms with the same byte AlarmBits.
+ *	Use the flag bool clearAlarmBits=True to explicitly clear byte AlarmBits on
+ *  call to getAXTime.
  */
 		void getA2Time(byte& A2Day, byte& A2Hour, byte& A2Minute, byte& AlarmBits, bool& A2Dy, bool& A2h12, bool& A2PM);
 			// Same as getA1Time();, but A2 only goes on seconds == 00.
+		void getA1Time(byte& A1Day, byte& A1Hour, byte& A1Minute, byte& A1Second, byte& AlarmBits, bool& A1Dy, bool& A1h12, bool& A1PM, bool& clearAlarmBits);
+			// Same as getA1Time();, but clears byte AlarmBits.
+		void getA1Time(byte& A1Day, byte& A1Hour, byte& A1Minute,byte& AlarmBits, bool& A1Dy, bool& A1h12, bool& A1PM, bool& clearAlarmBits);
+			// Same as getA1Time();, but clears byte AlarmBits.
 		void setA1Time(byte A1Day, byte A1Hour, byte A1Minute, byte A1Second, byte AlarmBits, bool A1Dy, bool A1h12, bool A1PM);
 			// Set the details for Alarm 1
 		void setA2Time(byte A2Day, byte A2Hour, byte A2Minute, byte AlarmBits, bool A2Dy, bool A2h12, bool A2PM);

--- a/tests/getAXTimeTest/getAXTimeTest.ino
+++ b/tests/getAXTimeTest/getAXTimeTest.ino
@@ -1,0 +1,80 @@
+/*
+getAXTimeTest.ino
+Jacob Nuernberg
+08/22
+
+Testing getAXTimeMethods.
+Code should generate the following output every 5s on the Serial Monitor:
+-> Initialize AlarmBits: 0
+-> getA1Time(): 1110
+-> getA2Time(): 1111110
+-> getA1Time(): 1110
+-> getA2Time(): 1110000
+
+Tested on:
+- Arduino nano
+
+*/
+
+#include <DS3231.h>
+#include <Wire.h>
+
+// Setup clock
+DS3231 myRTC;
+
+
+void setup() {
+    // Begin I2C communication
+    Wire.begin();
+
+    // Begin Serial communication
+    Serial.begin(57600);
+
+    // Setup alarm one to fire every minute
+    // No need to turn Alarm one on.
+    myRTC.turnOffAlarm(1);
+    myRTC.setA1Time(0, 0, 0, 0, 0b01111110, false, false, false);
+    myRTC.checkIfAlarm(1);
+
+    // Setup alarm two to fire every minute
+    // No need to turn Alarm two on.
+    myRTC.turnOffAlarm(2);
+    myRTC.setA2Time(0, 0, 0, 0b01111110, false, false, false);
+    myRTC.checkIfAlarm(2);
+}
+
+void loop() {
+    // Initialize AlarmBits
+    byte AlarmBits = 0x0;
+    Serial.print("Initialize AlarmBits: ");
+    Serial.println(AlarmBits, BIN);
+
+    // Initialize Others
+    byte ADay, AHour, AMinute, ASecond;
+    bool ADy, Ah12, APM;
+
+    // getA1Time (not clearing).
+    // Expected AlarmBits = 0x(0000)1110
+    myRTC.getA1Time(ADay, AHour, AMinute, ASecond, AlarmBits, ADy, Ah12, APM);
+    Serial.print("getA1Time(): ");
+    Serial.println(AlarmBits, BIN);
+
+    // getA2Time (not clearing).
+    // Expected AlarmBits = 0x01111110
+    myRTC.getA2Time(ADay, AHour, AMinute, AlarmBits, ADy, Ah12, APM);
+    Serial.print("getA2Time(): ");
+    Serial.println(AlarmBits, BIN);
+
+    // getA1Time (clearing).
+    // Expected AlarmBits = 0x(0000)1110
+    myRTC.getA1Time(ADay, AHour, AMinute, ASecond, AlarmBits, ADy, Ah12, APM, true);
+    Serial.print("getA1Time(): ");
+    Serial.println(AlarmBits, BIN);
+
+    // getA2Time (clearing).
+    // Expected AlarmBits = 0x01110000
+    myRTC.getA2Time(ADay, AHour, AMinute, AlarmBits, ADy, Ah12, APM, true);
+    Serial.print("getA2Time(): ");
+    Serial.println(AlarmBits, BIN);
+    delay(5000);
+}


### PR DESCRIPTION
### Summary
I tackled issue #51 in this PR by 
1. Adding a comment in `DS3231.h` as suggested by @franz-ap
2. Overloading `getAXTime()` with a `bool clearAlarmBits` parameter

I also provided a test for the `getAXTime()` methods in  a newly created tests subdirectory. This subdirectory is intended for rudimentary unit tests.

### Notes
I hope this resolves #51. @franz-ap, would you mind revieing the code and let me know, if this suits your needs?
If no objections arise, I will merge this PR and close #51 within the next week. 

Best regards, Jacob

