### PR TITLE
Remove Perform-Calculations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Presently, additional information about the functions is available in the [Examp
 - setA2Time()
 - turnOnAlarm()
 - turnOffAlarm()
+- checkAlarmEnabled()
 - checkIfAlarm()
 
 ### Manage DS3231 Hardware
@@ -215,7 +216,6 @@ The above list covers for interacting with the DS3231 hardware. Those listed bel
 - hour()
 - minute()
 - second()
-- dayOfTheWeek()
 - unixtime()
 
 <h3 id="RTClib_now_function">The Special <code>RTClib::now()</code> Function </h3>

--- a/README.md
+++ b/README.md
@@ -201,15 +201,6 @@ Presently, additional information about the functions is available in the [Examp
 - checkAlarmEnabled()
 - checkIfAlarm()
 
-### Perform Calculations on Time Data
-- date2days()
-- time2long()
-- unixtime()
-- bcd2bin()
-- bin2bcd()
-- decToBcd()
-- bcdToDec()
-
 ### Manage DS3231 Hardware
 - getTemperature()
 - enableOscillator()

--- a/README.md
+++ b/README.md
@@ -198,7 +198,6 @@ Presently, additional information about the functions is available in the [Examp
 - setA2Time()
 - turnOnAlarm()
 - turnOffAlarm()
-- checkAlarmEnabled()
 - checkIfAlarm()
 
 ### Manage DS3231 Hardware
@@ -206,8 +205,6 @@ Presently, additional information about the functions is available in the [Examp
 - enableOscillator()
 - enable32kHz()
 - oscillatorCheck()
-- readControlByte()
-- writeControlByte()
 
 The above list covers for interacting with the DS3231 hardware. Those listed below provide read-only access to information contained inside a DateTime object variable declared in program code.
 


### PR DESCRIPTION
Should not have been in there for two reasons:
1. the unixtime() function is part of DateTime
2. the other functions listed in this section were non-public