### PR TITLE
setEpoch(): unix time (convert internally to y2k) and no 100-yr offset

### DIFF
--- a/DS3231.cpp
+++ b/DS3231.cpp
@@ -279,7 +279,7 @@ void DS3231::setEpoch(time_t epoch, bool flag_localtime) {
 	setDoW(tmnow.tm_wday + 1);
 	setDate(tmnow.tm_mday);
 	setMonth(tmnow.tm_mon + 1);
-	setYear(tmnow.tm_year - 100);
+	setYear(tmnow.tm_year);
 }
 
 void DS3231::setSecond(byte Second) {

--- a/DS3231.cpp
+++ b/DS3231.cpp
@@ -261,6 +261,11 @@ byte DS3231::getYear() {
 // setEpoch function gives the epoch as parameter and feeds the RTC
 // epoch = UnixTime and starts at 01.01.1970 00:00:00
 void DS3231::setEpoch(time_t epoch, bool flag_localtime) {
+	/*
+	 Arduino implementation of these `time` C++ functions
+	 is from Jan 1st, 2000, instead of Jan 1st, 1970.
+	*/
+	epoch -= SECONDS_FROM_1970_TO_2000; // Unix to y2k time
 	struct tm tmnow;
 	if (flag_localtime) {
 		localtime_r(&epoch, &tmnow);


### PR DESCRIPTION
*Untested in software or hardware.*

This should provide the offset required to make the datum for `setEpoch()` be 01/01/1970 instead of 01/01/2000, as is expected both from its own documentation and from the way much of the rest of this library works (even if the DS3231 itself zeros out at 01/01/2000).

Tagging relevant folks: @hasenradball @IowaDave @bill-ba @leslieadams57

And issue #53
And this PR: https://github.com/NorthernWidget/DS3231/pull/60

I'm still not sure if `tm_wday` and `tm_mon` need their `+1`s. Going to look at the differences between the C++ library and the DS3231 data sheet at some point after this, and add any changes as needed to this PR.
