### PR TITLE
[BUGFIX & new example]: add new example and BUGFIX for __AVR__ for function DS3231::setEpoch()

### DIFF
--- a/DS3231.cpp
+++ b/DS3231.cpp
@@ -260,7 +260,11 @@ byte DS3231::getYear() {
 
 // setEpoch function gives the epoch as parameter and feeds the RTC
 // epoch = UnixTime and starts at 01.01.1970 00:00:00
+// HINT: => the AVR time.h Lib is based on the year 2000
 void DS3231::setEpoch(time_t epoch, bool flag_localtime) {
+#if defined (__AVR__)
+	epoch -= SECONDS_FROM_1970_TO_2000;
+#endif
 	struct tm tmnow;
 	if (flag_localtime) {
 		localtime_r(&epoch, &tmnow);
@@ -271,10 +275,10 @@ void DS3231::setEpoch(time_t epoch, bool flag_localtime) {
 	setSecond(tmnow.tm_sec);
 	setMinute(tmnow.tm_min);
 	setHour(tmnow.tm_hour);
-	setDoW(tmnow.tm_wday + 1);
+	setDoW(tmnow.tm_wday + 1U);
 	setDate(tmnow.tm_mday);
-	setMonth(tmnow.tm_mon + 1);
-	setYear(tmnow.tm_year - 100);
+	setMonth(tmnow.tm_mon + 1U);
+	setYear(tmnow.tm_year - 100U);
 }
 
 void DS3231::setSecond(byte Second) {

--- a/examples/setEpoch/setEpoch.ino
+++ b/examples/setEpoch/setEpoch.ino
@@ -1,0 +1,96 @@
+#include <Wire.h>
+#include <DS3231.h>
+
+void showTimeFormated(time_t t) {
+#if defined (__AVR__)
+    t -= 946684800UL;
+#endif
+  char buffer[50];
+  struct tm *ptm;
+  ptm = gmtime (&t);
+  const char * timeformat {"%a %F %X - weekday %w; CW %W"};
+  strftime(buffer, sizeof(buffer), timeformat, ptm);
+  Serial.print(buffer);
+  Serial.print("\n");
+}
+
+constexpr time_t tstmp {1660644000UL};
+
+RTClib myRTC;
+DS3231 Clock;
+
+void setup () {
+    Serial.begin(115200);
+    Wire.begin();
+    delay(500);
+    Serial.println("\n\n\nTest of DS3231 - setEpoch()\n\n\n");
+
+#if defined (__AVR__)
+#warning using AVR platform
+    Serial.println("AVR Microcontroller Ready!");
+    Wire.begin();
+#elif defined (ESP8266)
+Serial.println("ESP8266 Microcontroller Ready!");
+#warning using espressif platform
+    // SDA = 0, SCL = 2
+    Wire.begin(0U, 2U);
+#endif
+
+    // set the Ds3131 with a specific UnixTimestamp
+    // ==>  	Tue Aug 16 2022 10:00:00 GMT+0000 - weekday 2 (0 = Sunday); CW 33
+    // ==>    1660644000
+    
+    Serial.println("Tue Aug 16 2022 10:00:00 GMT+0000 - weekday 2 (0 = Sunday); CW 33");
+    Serial.println("UnixTimestamp - 1660644000");
+
+
+    // feed UnixTimeStamp and don' t use localtime
+    Clock.setEpoch(tstmp, false);
+    // set to 24h
+    Clock.setClockMode(false);
+
+    // Just for verification of DS3231 Data
+    // check now the data from ESP8266 and DS3231
+    // get year
+    bool century = false;
+    bool h12Flag;
+    bool pmFlag;
+    DateTime now = myRTC.now();
+    Serial.print("\n\n");
+    Serial.print(" DateTime of DS3231:     ");
+    Serial.print(Clock.getYear(), DEC);
+    Serial.print("-");
+    Serial.print(Clock.getMonth(century), DEC);
+    Serial.print("-");
+    Serial.print(Clock.getDate(), DEC);
+    Serial.print(" ");
+    Serial.print(Clock.getHour(h12Flag, pmFlag), DEC);
+    Serial.print(":");
+    Serial.print(Clock.getMinute(), DEC);
+    Serial.print(":");
+    Serial.print(Clock.getSecond(), DEC);
+    Serial.print("  -  weekday ");
+    Serial.print(Clock.getDoW(), DEC);
+    Serial.println();
+
+    Serial.print("\n\n");
+    Serial.print(" DateTime of RTC:        ");
+    Serial.print(now.year(), DEC);
+    Serial.print("-");
+    Serial.print(now.month(), DEC);
+    Serial.print("-");
+    Serial.print(now.day(), DEC);
+    Serial.print(" ");
+    Serial.print(now.hour(), DEC);
+    Serial.print(":");
+    Serial.print(now.minute(), DEC);
+    Serial.print(":");
+    Serial.print(now.second(), DEC);
+    Serial.println();
+
+    Serial.print("\n\n Output of Struct tm:  ");
+    showTimeFormated(tstmp);
+}
+
+void loop () {
+}


### PR DESCRIPTION
as discussed in PR #65.