### PR TITLE
Added rudimentary +,-, >, <, == operators for DateTime objects and tests

### DIFF
--- a/DS3231.cpp
+++ b/DS3231.cpp
@@ -194,19 +194,35 @@ DateTime DateTime::operator + (uint32_t const &rhs){
 	return DateTime(this->unixtime() + rhs);
 }
 
-	//Greater-than returns TRUE if any non-UNIX time fields in a DateTime in this are strictly greater than values in rhs, evaluated in hierarchical order 
+	//Greater-than returns TRUE if the UNIX time of the LHS is strictly greater than the UNIX time of the RHS
 bool DateTime::operator > (DateTime const &rhs){
-	return this->year() > rhs.year() || this->month() > rhs.month() || this->day() > rhs.day() || this->hour() > rhs.hour() || this->minute() > rhs.minute() || this->second() > rhs.second();
+	return this->unixtime() > rhs.unixtime();
 }
-	//Less-than returns TRUE if any non-UNIX time fields in a DateTime in this are strictly lesser than values in rhs, evaluated in hierarchical order 
+	//Less-than returns TRUE if the UNIX time of the LHS is strictly less than the UNIX time of the RHS
 bool DateTime::operator < (DateTime const &rhs){
-	return this->year() < rhs.year() || this->month() < rhs.month() || this->day() < rhs.day() || this->hour() < rhs.hour() || this->minute() < rhs.minute() || this->second() < rhs.second();
+	return this->unixtime() < rhs.unixtime();
 }
 	
-	//Comparison checks if all non-UNIX time fields in a DateTime match, but NOT if the UNIX time matches,
-	//since UNIX time involes setting the clock to UTC
+	//Comparison checks if the UNIX time matches
 bool DateTime::operator == (DateTime const &rhs){
-	return this->second() == rhs.second() && this->minute() == rhs.minute() && this->hour() == rhs.hour() && this->day() == rhs.day() && this->month() == rhs.month() && this->year() == rhs.year();
+	return this->unixtime() == rhs.unixtime();
+}
+
+	//The following operators make use of the operators defined above to extend functionality
+
+	//!= checks if the UNIX time does not match
+bool DateTime::operator != (DateTime const &rhs){
+	return !(*this == rhs);
+}
+
+	//>= returns TRUE if the UNIX time of the LHS is > or is == the UNIX time of the RHS
+bool DateTime::operator >= (DateTime const &rhs){
+	return (*this > rhs || *this == rhs);
+}
+
+	//<= checks if the UNIX time of the LHS is > RHS or is == the UNIX time of the RHS
+bool DateTime::operator <= (DateTime const &rhs){
+	return (*this < rhs || *this == rhs);
 }
 
 ///// ERIC'S ORIGINAL CODE FOLLOWS /////

--- a/DS3231.cpp
+++ b/DS3231.cpp
@@ -180,6 +180,35 @@ DateTime RTClib::now(TwoWire & _Wire) {
   return DateTime (y, m, d, hh, mm, ss);
 }
 
+//Subtraction returns difference in seconds between 2 DateTimes.
+//This is signed so that you can express situations when the LHS is earlier in time than the RHS.
+long DateTime::operator - (DateTime const &rhs){
+	return this->unixtime() - rhs.unixtime();
+}
+
+//Addition accepts seconds as the RHS, RHS >= 0
+//and returns a new DateTime where RHS is added to LHS.
+//I did not implement addition of negative numbers because that causes underflow with the
+//unixtime uint32_t.
+DateTime DateTime::operator + (uint32_t const &rhs){
+	return DateTime(this->unixtime() + rhs);
+}
+
+	//Greater-than returns TRUE if any non-UNIX time fields in a DateTime in this are strictly greater than values in rhs, evaluated in hierarchical order 
+bool DateTime::operator > (DateTime const &rhs){
+	return this->year() > rhs.year() || this->month() > rhs.month() || this->day() > rhs.day() || this->hour() > rhs.hour() || this->minute() > rhs.minute() || this->second() > rhs.second();
+}
+	//Less-than returns TRUE if any non-UNIX time fields in a DateTime in this are strictly lesser than values in rhs, evaluated in hierarchical order 
+bool DateTime::operator < (DateTime const &rhs){
+	return this->year() < rhs.year() || this->month() < rhs.month() || this->day() < rhs.day() || this->hour() < rhs.hour() || this->minute() < rhs.minute() || this->second() < rhs.second();
+}
+	
+	//Comparison checks if all non-UNIX time fields in a DateTime match, but NOT if the UNIX time matches,
+	//since UNIX time involes setting the clock to UTC
+bool DateTime::operator == (DateTime const &rhs){
+	return this->second() == rhs.second() && this->minute() == rhs.minute() && this->hour() == rhs.hour() && this->day() == rhs.day() && this->month() == rhs.month() && this->year() == rhs.year();
+}
+
 ///// ERIC'S ORIGINAL CODE FOLLOWS /////
 
 byte DS3231::getSecond() {

--- a/DS3231.cpp
+++ b/DS3231.cpp
@@ -35,6 +35,7 @@ Released into the public domain.
 //#include "WProgram.h"
 #include <Arduino.h>
 
+#define UINT32_MAX 4294967295
 
 #define CLOCK_ADDRESS 0x68
 
@@ -191,7 +192,13 @@ long DateTime::operator - (DateTime const &rhs){
 //I did not implement addition of negative numbers because that causes underflow with the
 //unixtime uint32_t.
 DateTime DateTime::operator + (uint32_t const &rhs){
-	return DateTime(this->unixtime() + rhs);
+	//guard against overflow. if this->unixtime() + rhs > UINT32_MAX, just return the maximum value
+	if (UINT32_MAX - rhs < this->unixtime()){
+		return UINT32_MAX;
+	} else {
+		//otherwise, perform the addition normally.
+		return DateTime(this->unixtime() + rhs);
+	}
 }
 
 	//Greater-than returns TRUE if the UNIX time of the LHS is strictly greater than the UNIX time of the RHS

--- a/DS3231.h
+++ b/DS3231.h
@@ -56,17 +56,30 @@ public:
     //and returns a new DateTime
     DateTime operator + (uint32_t const &rhs);
 
-    //Greater-than returns TRUE if all non-UNIX time fields in a DateTime are
-    // > corresponding fields in rhs when evaluated hierarchically
+    //Greater-than returns TRUE if UNIX time of a DateTime is
+    // > corresponding UNIX time of the RHS
     bool operator > (DateTime const &rhs);
 
-    //Less-than returns TRUE if all non-UNIX time fields in a DateTime are
-    // < corresponding fields in rhs when evaluated hierarchically
+    //Less-than returns TRUE if UNIX time of a DateTime is
+    // < corresponding UNIX time of the RHS
     bool operator < (DateTime const &rhs);
 	
-    //Comparison checks if all non-UNIX time fields in a DateTime match, but NOT if the UNIX time matches,
-    //since UNIX time involes setting the clock to UTC
+    //Equality returns TRUE if UNIX time of a DateTime is
+	// == to corresponding UNIX time of the RHS
     bool operator == (DateTime const &rhs);
+
+	//Inequality returns TRUE if UNIX time of a DateTime is
+	// != to corresponding UNIX time of the RHS
+	bool operator != (DateTime const &rhs);
+
+	//Greater-than-or-equal-to returns TRUE if UNIX time of a DateTime is
+	// >= to corresponding UNIX time of the RHS
+	bool operator >= (DateTime const &rhs);
+	
+	//Less-than-or-equal-to returns TRUE if UNIX time of a DateTime is
+	// <= to corresponding UNIX time of the RHS
+	bool operator <= (DateTime const &rhs);
+
 protected:
     uint8_t yOff, m, d, hh, mm, ss;
 };

--- a/DS3231.h
+++ b/DS3231.h
@@ -45,6 +45,28 @@ public:
     // OBTAIN TRUE UNIX TIME SINCE EPOCH, YOU MUST CALL THIS COMMAND AFTER
     // SETTING YOUR CLOCK TO UTC
     uint32_t unixtime(void) const;
+
+	//Operators to support DateTime comparisons
+
+    //Subtraction returns the difference, in seconds, between two DateTimes
+    //allows for negative differences (i.e. rhs > lhs).
+    long operator - (DateTime const &rhs);
+
+    //Addition accepts a positive number of seconds to add
+    //and returns a new DateTime
+    DateTime operator + (uint32_t const &rhs);
+
+    //Greater-than returns TRUE if all non-UNIX time fields in a DateTime are
+    // > corresponding fields in rhs when evaluated hierarchically
+    bool operator > (DateTime const &rhs);
+
+    //Less-than returns TRUE if all non-UNIX time fields in a DateTime are
+    // < corresponding fields in rhs when evaluated hierarchically
+    bool operator < (DateTime const &rhs);
+	
+    //Comparison checks if all non-UNIX time fields in a DateTime match, but NOT if the UNIX time matches,
+    //since UNIX time involes setting the clock to UTC
+    bool operator == (DateTime const &rhs);
 protected:
     uint8_t yOff, m, d, hh, mm, ss;
 };

--- a/examples/operator_tests/operator_tests.ino
+++ b/examples/operator_tests/operator_tests.ino
@@ -1,0 +1,91 @@
+#include <DS3231.h>
+
+void setup() {
+  // put your setup code here, to run once:
+  
+  Serial.begin(9600);
+  while(!Serial){};
+  
+  Serial.print("Testing Subtraction: 1 Jan 2000 00:00:01 - 1 Jan 2000 00:00:00 = ");
+  Serial.print(DateTime(946684801) - DateTime(946684800));Serial.println(" second");
+
+  Serial.print("Testing Subtraction: 1 Jan 2000 00:01:01 - 1 Jan 2000 00:00:00 = ");
+  Serial.print(DateTime(946684861) - DateTime(946684800));Serial.println(" seconds");
+
+  Serial.print("Testing Subtraction: 1 Jan 2000 00:00:00 - 1 Jan 2000 00:00:01 = ");
+  Serial.print(DateTime(946684800) - DateTime(946684801));Serial.println(" seconds");
+
+  DateTime result = DateTime(946684801) + 60;
+  Serial.print("Testing Addition: 1 Jan 2000 00:00:01 + 60 seconds = ");
+  Serial.print(result.day());Serial.print(' ');
+  Serial.print(result.month());Serial.print(' ');
+  Serial.print(result.year());Serial.print(' ');
+  Serial.print(result.hour());Serial.print(':');
+  Serial.print(result.minute());Serial.print(':');
+  Serial.println(result.second());
+
+  Serial.println("TESTING >");
+
+  Serial.print("1 Jan 2000 00:00:01 > 1 Jan 2000 00:00:00 = ");
+  (DateTime(946684801) > DateTime(946684800)) ? Serial.println("TRUE") : Serial.println("FALSE");
+  
+  Serial.print("1 Jan 2000 00:01:00 > 1 Jan 2000 00:00:01 = ");
+  (DateTime(946684860) > DateTime(946684801)) ? Serial.println("TRUE") : Serial.println("FALSE");
+
+  Serial.print("1 Jan 2000 01:00:00 > 1 Jan 2000 00:01:01 = ");
+  (DateTime(946688400) > DateTime(946684861)) ? Serial.println("TRUE") : Serial.println("FALSE");
+
+  Serial.print("2 Jan 2000 00:00:00 > 1 Jan 2000 00:01:01 = ");
+  (DateTime(946789200) > DateTime(946684861)) ? Serial.println("TRUE") : Serial.println("FALSE");
+
+  Serial.print("1 Feb 2000 00:00:00 > 1 Jan 2000 00:01:01 = ");
+  (DateTime(949381200) > DateTime(946684861)) ? Serial.println("TRUE") : Serial.println("FALSE");
+
+  Serial.print("1 Jan 2001 00:00:00 > 1 Jan 2000 00:01:01 = ");
+  (DateTime(978325200) > DateTime(946684861)) ? Serial.println("TRUE") : Serial.println("FALSE");
+
+  Serial.print("1 Jan 2000 00:00:00 > 1 Jan 2000 00:00:00 = ");
+  (DateTime(946684800) > DateTime(946684800)) ? Serial.println("TRUE") : Serial.println("FALSE");
+
+  Serial.print("1 Jan 2000 00:00:00 > 1 Jan 2000 00:00:01 = ");
+  (DateTime(946684800) > DateTime(946684801)) ? Serial.println("TRUE") : Serial.println("FALSE");
+
+  Serial.println("TESTING <");
+
+  Serial.print("1 Jan 2000 00:00:00 < 1 Jan 2000 00:00:01 = ");
+  (DateTime(946684800) < DateTime(946684801)) ? Serial.println("TRUE") : Serial.println("FALSE");
+  
+  Serial.print("1 Jan 2000 00:00:01 < 1 Jan 2000 00:01:00 = ");
+  (DateTime(946684801) < DateTime(946684860)) ? Serial.println("TRUE") : Serial.println("FALSE");
+
+  Serial.print("1 Jan 2000 00:01:00 < 1 Jan 2000 01:00:00 = ");
+  (DateTime(946684860) < DateTime(946702860)) ? Serial.println("TRUE") : Serial.println("FALSE");
+
+  Serial.print("1 Jan 2000 01:00:00 < 2 Jan 2000 00:00:00 = ");
+  (DateTime(946702860) < DateTime(946789200)) ? Serial.println("TRUE") : Serial.println("FALSE");
+
+  Serial.print("2 Jan 2000 00:00:00 < 1 Feb 2000 00:00:00 = ");
+  (DateTime(946789200) < DateTime(949381200)) ? Serial.println("TRUE") : Serial.println("FALSE");
+
+  Serial.print("1 Feb 2000 00:00:00 < 1 Feb 2001 00:00:00 = ");
+  (DateTime(949381200) < DateTime(981003600)) ? Serial.println("TRUE") : Serial.println("FALSE");
+
+  Serial.print("1 Jan 2000 00:00:00 < 1 Jan 2000 00:00:00 = ");
+  (DateTime(946684800) < DateTime(946684800)) ? Serial.println("TRUE") : Serial.println("FALSE");
+
+  Serial.print("1 Jan 2000 00:00:01 < 1 Jan 2001 00:00:00 = ");
+  (DateTime(946684801) < DateTime(946684800)) ? Serial.println("TRUE") : Serial.println("FALSE");
+
+  Serial.println("TESTING ==");
+  
+  Serial.print("1 Jan 2000 00:00:00 == 1 Jan 2000 00:00:00 ? ");
+  (DateTime(946684800) == DateTime(946684800)) ? Serial.println("TRUE") : Serial.println("FALSE");
+
+  Serial.print("1 Jan 2000 00:00:00 == 1 Jan 2001 00:00:01 ? ");
+  (DateTime(946684800) == DateTime(946684801)) ? Serial.println("TRUE") : Serial.println("FALSE");
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+
+}


### PR DESCRIPTION
I have added <, >, and == operator overloading for the DateTime class.

These comparison operators compare the year, month, day, hour, minute and seconds fields directly, because unixtime only matches if the timezone is set to UTC.

I have also added + and - operators with the following behaviors:

+ operator takes a DateTime (LHS) and a number of seconds (RHS) and returns a new DateTime that many seconds greater than the LHS. The RHS must be >= 0, because adding negatives causes underflow with the underlying UnixTime variable.

- operator returns the difference in seconds between two DateTimes. This value can be negative, meaning LHS is chronologically before the RHS.