### PR TITLE
CI by compiling the examples

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,0 +1,16 @@
+name: Compile examples
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  compile-examples:
+    runs-on: ubuntu-latest
+
+    steps:
+        - uses: actions/checkout@v3
+        - uses: arduino/compile-sketches@v1
+          with:
+            libraries: |
+              - source-path: ./


### PR DESCRIPTION
Hello,
thanks for this Library, i use it in some projects and it works great for me!
As there is currently no CI here maybe this can help you? 

This PR brings a github action that runs on every push or pull request.  It takes the current state of the repository and compiles every example. It is done using the official arduino "compile-sketch" action: https://github.com/arduino/compile-sketches
It is a minimalistic setup as it compiles only for the default board (Arduino Uno). 
If all examples compiled without error, its considered passing. 

An example run: https://github.com/designer2k2/DS3231/actions/runs/3800802241/jobs/6464618235

![grafik](https://user-images.githubusercontent.com/1591573/210050691-00bbc2c1-f046-4506-b9a3-578f8f552b05.png)

greetings from Austria,
Stephan