### PR TITLE
Show release 1.1.1 on the library manager

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=DS3231
-version=1.1.0
+version=1.1.1
 author=Andrew Wickert <awickert@umn.edu>, Eric Ayars, Jean-Claude Wippler, Northern Widget LLC <info@northernwidget.com>
 maintainer=Andrew Wickert <awickert@umn.edu>
 sentence=Arduino library for the DS3231 real-time clock (RTC)


### PR DESCRIPTION
Upating the library.properties to match the release 1.1.1

This would fix: https://github.com/NorthernWidget/DS3231/issues/74