### PR TITLE
delete unimplemented method prototype secondstime()

### DIFF
--- a/DS3231.h
+++ b/DS3231.h
@@ -44,8 +44,6 @@ public:
     uint8_t second() const      { return ss; }
     uint8_t dayOfTheWeek() const;
 
-    // 32-bit times as seconds since 1/1/2000
-    long secondstime() const;
     // 32-bit times as seconds since 1/1/1970
     // THE ABOVE COMMENT IS CORRECT FOR LOCAL TIME; TO USE THIS COMMAND TO
     // OBTAIN TRUE UNIX TIME SINCE EPOCH, YOU MUST CALL THIS COMMAND AFTER


### PR DESCRIPTION
Possible duplication of remarks uploaded previously.

This PR deletes lines 47-48 in DS3231.h where a DateTime class method named "secondstime()" is prototyped. Line 47 is a comment relating to this prototype.

I do not find the prototype implemented, nor any other instance of the string "secondstime" in DS3231.cpp. It appears to be a thought that someone had at some time in the past, to give the DateTime class two methods for returning a timestamp, where the timestamps could have different numerical values, one counting from year 1970 and the other from year 2000. However, it was not completed.

I would pursue deletion of the prototype for two, other reasons also. Firstly, incompatible return type. Its return value is typed "long", a signed value, which is inconsistent with the usage of uint32_t elsewhere in the Library. Secondly, redundant. Documentation explains how the value returned by the unixtime() method relates to the Library's design constraint of dates only between 2000 and 2099, inclusive.